### PR TITLE
Save contract deployment data to deployments folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Web3 Monorepo Template
 
 This is an opinionated monorepo template for web3 projects. It uses Hardhat for [smart contracts](./apps/contracts/README.md) and Next.js for the [web app](./apps/web/README.md).
+
+## Contract Deployments
+
+When contracts are deployed, their deployment data (address, ABI, constructor arguments) is automatically saved to the `apps/contracts/deployments/{chainId}/` directory. This data can be accessed from the web app using the `getDeployment` helper function:
+
+```typescript
+import { getDeployment } from '@/lib/getDeployment'
+
+// Get deployment data for a contract on a specific chain
+const { address, abi } = getDeployment(chainId, 'Contract')
+```

--- a/apps/contracts/README.md
+++ b/apps/contracts/README.md
@@ -1,6 +1,6 @@
 # Contracts
 
-Hardhat project for building smart contracts. The deploy script uses CREATE2 to easily mine a vanity address.
+Hardhat project for building smart contracts. The deploy script uses CREATE2 to easily mine a vanity address and automatically saves deployment data (address, ABI, constructor arguments) to the `deployments/{chainId}/` directory.
 
 ## Local Development
 

--- a/apps/contracts/scripts/deploy.ts
+++ b/apps/contracts/scripts/deploy.ts
@@ -1,7 +1,9 @@
 import hre from 'hardhat'
 import { encodeAbiParameters } from 'viem/utils'
+import { Contract } from 'ethers'
 
 import { generateSaltAndDeploy } from './lib/create2'
+import { saveDeployment } from './lib/saveDeployment'
 
 async function main() {
   const contractName = 'Contract'
@@ -15,7 +17,7 @@ async function main() {
     constructorArguments
   )
 
-  const { address } = await generateSaltAndDeploy({
+  const { address, contract } = await generateSaltAndDeploy({
     vanity: '0x000',
     encodedArgs,
     contractName,
@@ -24,6 +26,10 @@ async function main() {
   })
 
   console.log(`Deployed ${contractName} to ${address}`)
+
+  // Save deployment data
+  const chainId = (await hre.ethers.provider.getNetwork()).chainId
+  await saveDeployment(contract as Contract, Number(chainId), constructorArguments)
 
   try {
     // Wait 30 seconds for block explorers to index the deployment

--- a/apps/contracts/scripts/lib/create2.ts
+++ b/apps/contracts/scripts/lib/create2.ts
@@ -96,5 +96,9 @@ export async function generateSaltAndDeploy({
 
   await publicClient.waitForTransactionReceipt({ hash: deployTx })
 
-  return { salt, address: expectedAddress }
+  // Get the contract instance
+  const Contract = await hre.ethers.getContractFactory(contractName)
+  const contract = Contract.attach(expectedAddress)
+
+  return { salt, address: expectedAddress, contract }
 }

--- a/apps/contracts/scripts/lib/saveDeployment.ts
+++ b/apps/contracts/scripts/lib/saveDeployment.ts
@@ -1,0 +1,41 @@
+import fs from 'fs'
+import path from 'path'
+import { Contract } from 'ethers'
+
+export interface DeploymentData {
+  address: string
+  abi: any
+  constructorArguments?: any[]
+  chainId: number
+  deploymentDate: string
+}
+
+export async function saveDeployment(
+  contract: Contract,
+  chainId: number,
+  constructorArguments?: any[]
+) {
+  const deploymentData: DeploymentData = {
+    address: await contract.getAddress(),
+    abi: contract.interface.format(),
+    constructorArguments,
+    chainId,
+    deploymentDate: new Date().toISOString(),
+  }
+
+  const deploymentsDir = path.join(__dirname, '../../deployments')
+  if (!fs.existsSync(deploymentsDir)) {
+    fs.mkdirSync(deploymentsDir, { recursive: true })
+  }
+
+  const chainDir = path.join(deploymentsDir, chainId.toString())
+  if (!fs.existsSync(chainDir)) {
+    fs.mkdirSync(chainDir, { recursive: true })
+  }
+
+  const contractName = await contract.name?.() || 'Contract'
+  const filePath = path.join(chainDir, `${contractName}.json`)
+
+  fs.writeFileSync(filePath, JSON.stringify(deploymentData, null, 2))
+  console.log(`Deployment data saved to ${filePath}`)
+}

--- a/apps/web/src/lib/getDeployment.ts
+++ b/apps/web/src/lib/getDeployment.ts
@@ -1,0 +1,21 @@
+import fs from 'fs'
+import path from 'path'
+
+export interface DeploymentData {
+  address: string
+  abi: any
+  constructorArguments?: any[]
+  chainId: number
+  deploymentDate: string
+}
+
+export function getDeployment(chainId: number, contractName: string): DeploymentData {
+  const deploymentsPath = path.join(process.cwd(), '../contracts/deployments', chainId.toString(), `${contractName}.json`)
+  
+  if (!fs.existsSync(deploymentsPath)) {
+    throw new Error(`No deployment found for contract ${contractName} on chain ${chainId}`)
+  }
+
+  const deploymentData = JSON.parse(fs.readFileSync(deploymentsPath, 'utf-8'))
+  return deploymentData
+}


### PR DESCRIPTION
Fixes #1

This PR adds functionality to save contract deployment data (address, ABI, constructor arguments) to a `deployments` folder, similar to how it's done in ensdomains/ens-contracts.

Changes:
- Add `saveDeployment` helper to store contract data in `apps/contracts/deployments/{chainId}/`
- Return contract instance from `create2` deploy function
- Add `getDeployment` helper to web package for easy access to deployment data
- Update documentation in both main and contracts README

Example usage in web app:
```typescript
import { getDeployment } from '@/lib/getDeployment'

const { address, abi } = getDeployment(chainId, 'Contract')
```